### PR TITLE
fix compile-scss.sh running on sh instead of bash???

### DIFF
--- a/tools/compile-scss.sh
+++ b/tools/compile-scss.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 command=$1
 


### PR DESCRIPTION
turns out i upgraded the vps to debian 12 for nothing. git for windows seemingly aliases "sh" into "bash", while debian still has "sh" and "bash" as separate things.